### PR TITLE
Test non-CUDA Thrust headers with CUDA compiler and drop unused defines

### DIFF
--- a/cmake/CCCLGenerateHeaderTests.cmake
+++ b/cmake/CCCLGenerateHeaderTests.cmake
@@ -26,7 +26,7 @@
 function(cccl_generate_header_tests target_name project_include_path)
   set(options)
   set(oneValueArgs LANGUAGE HEADER_TEMPLATE)
-  set(multiValueArgs GLOBS EXCLUDES HEADERS DEFINES)
+  set(multiValueArgs GLOBS EXCLUDES HEADERS)
   cmake_parse_arguments(CGHT "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
 
   if (CGHT_UNPARSED_ARGUMENTS)


### PR DESCRIPTION
## Summary
- build Thrust header tests for non-CUDA backends with both host and CUDA compilers
- remove unused DEFINES argument from cccl header test helper

## Testing
- `pre-commit run --files cmake/CCCLGenerateHeaderTests.cmake thrust/cmake/ThrustHeaderTesting.cmake`
- `ninja -C build/thrust-cpp17 thrust/CMakeFiles/thrust.cpp.omp.cpp17.headers.base.dir/headers/thrust.cpp.omp.cpp17.headers.base/thrust/advance.h.cpp.o`
- `ninja -C build/thrust-cpp17 thrust/CMakeFiles/thrust.cpp.omp.cpp17.headers.base.cuda.dir/headers/thrust.cpp.omp.cpp17.headers.base.cuda/thrust/advance.h.cu.o`


------
https://chatgpt.com/codex/tasks/task_e_68b8ba0510c4832b826fd415cc5d54eb