### PR TITLE
Enable ASan builds and CI job for c_parallel

### DIFF
--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -8,6 +8,7 @@ workflows:
   #   - {jobs: ['test'], project: 'thrust', std: 17, ctk: '12.X', cxx: ['gcc12', 'clang16']}
   #
   override:
+    - {jobs: ['test'], project: 'cccl_c_parallel', ctk: '13.X', cxx: 'gcc13', gpu: 'rtx2080', cmake_options: '-DCCCL_ENABLE_ASAN=ON -DCMAKE_BUILD_TYPE=Debug'}
 
   pull_request:
     # Old CTK: Oldest/newest supported host compilers:

--- a/cmake/CCCLBuildCompilerTargets.cmake
+++ b/cmake/CCCLBuildCompilerTargets.cmake
@@ -77,7 +77,7 @@ function(cccl_build_compiler_interface interface_target cuda_compile_options cxx
   foreach (link_option IN LISTS link_options)
     target_link_options(${interface_target} INTERFACE
       $<$<LINK_LANGUAGE:CXX>:${link_option}>
-      $<$<LINK_LANG_AND_ID:CUDA,NVIDIA>:SHELL:-Xlinker=${link_option}>
+      $<$<LINK_LANG_AND_ID:CUDA,NVIDIA>:SHELL:-Xlinker ${link_option}>
     )
   endforeach()
 

--- a/cub/cmake/CubBuildCompilerTargets.cmake
+++ b/cub/cmake/CubBuildCompilerTargets.cmake
@@ -14,11 +14,13 @@
 function(cub_build_compiler_targets)
   set(cuda_compile_options)
   set(cxx_compile_options)
+  set(link_options)
   set(cxx_compile_definitions)
 
   cccl_build_compiler_interface(cub.compiler_interface
     "${cuda_compile_options}"
     "${cxx_compile_options}"
+    "${link_options}"
     "${cxx_compile_definitions}"
   )
 

--- a/cudax/cmake/cudaxBuildCompilerTargets.cmake
+++ b/cudax/cmake/cudaxBuildCompilerTargets.cmake
@@ -19,6 +19,7 @@ find_package(Thrust CONFIG REQUIRED
 function(cudax_build_compiler_targets)
   set(cuda_compile_options)
   set(cxx_compile_options)
+  set(link_options)
   set(cxx_compile_definitions)
 
   if ("MSVC" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
@@ -51,6 +52,7 @@ function(cudax_build_compiler_targets)
   cccl_build_compiler_interface(cudax.compiler_interface
     "${cuda_compile_options}"
     "${cxx_compile_options}"
+    "${link_options}"
     "${cxx_compile_definitions}"
   )
 

--- a/libcudacxx/cmake/LibcudacxxBuildCompilerTargets.cmake
+++ b/libcudacxx/cmake/LibcudacxxBuildCompilerTargets.cmake
@@ -14,6 +14,7 @@
 function(libcudacxx_build_compiler_targets)
   set(cuda_compile_options)
   set(cxx_compile_options)
+  set(link_options)
   set(cxx_compile_definitions)
 
   # Set test specific flags
@@ -26,6 +27,7 @@ function(libcudacxx_build_compiler_targets)
   cccl_build_compiler_interface(libcudacxx.compiler_interface
     "${cuda_compile_options}"
     "${cxx_compile_options}"
+    "${link_options}"
     "${cxx_compile_definitions}"
   )
 

--- a/thrust/cmake/ThrustBuildCompilerTargets.cmake
+++ b/thrust/cmake/ThrustBuildCompilerTargets.cmake
@@ -14,6 +14,7 @@
 function(thrust_build_compiler_targets)
   set(cuda_compile_options)
   set(cxx_compile_options)
+  set(link_options)
   set(cxx_compile_definitions)
 
   if ("MSVC" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
@@ -29,6 +30,7 @@ function(thrust_build_compiler_targets)
   cccl_build_compiler_interface(thrust.compiler_interface
     "${cuda_compile_options}"
     "${cxx_compile_options}"
+    "${link_options}"
     "${cxx_compile_definitions}"
   )
 


### PR DESCRIPTION
## Summary
- add `CCCL_ENABLE_ASAN` option and propagate sanitizer compile/link flags
- rely on CI to set Debug build type when ASan is enabled
- add c_parallel ASan test job to CI override matrix

## Testing
- `CCCL_BUILD_INFIX=dev ./ci/build_cccl_c_parallel.sh -configure -cmake-options "-DCCCL_ENABLE_ASAN=ON -DCMAKE_BUILD_TYPE=Debug"`
- `pre-commit run --files CMakeLists.txt ci/matrix.yaml cmake/CCCLBuildCompilerTargets.cmake cub/cmake/CubBuildCompilerTargets.cmake cudax/cmake/cudaxBuildCompilerTargets.cmake libcudacxx/cmake/LibcudacxxBuildCompilerTargets.cmake thrust/cmake/ThrustBuildCompilerTargets.cmake`

------
https://chatgpt.com/codex/tasks/task_e_68b783ff298c832b9d4ea10aef09e73a