### PR TITLE
Refactor compile option handling order and broaden ASAN coverage

### DIFF
--- a/cub/cmake/CubBuildCompilerTargets.cmake
+++ b/cub/cmake/CubBuildCompilerTargets.cmake
@@ -12,14 +12,16 @@
 #   cub.compiler_interface and cccl.compiler_interface_cppXX.
 
 function(cub_build_compiler_targets)
-  set(cuda_compile_options)
+  set(c_compile_options)
   set(cxx_compile_options)
+  set(cuda_compile_options)
   set(link_options)
   set(cxx_compile_definitions)
 
   cccl_build_compiler_interface(cub.compiler_interface
-    "${cuda_compile_options}"
+    "${c_compile_options}"
     "${cxx_compile_options}"
+    "${cuda_compile_options}"
     "${link_options}"
     "${cxx_compile_definitions}"
   )

--- a/cudax/cmake/cudaxBuildCompilerTargets.cmake
+++ b/cudax/cmake/cudaxBuildCompilerTargets.cmake
@@ -17,8 +17,9 @@ find_package(Thrust CONFIG REQUIRED
 )
 
 function(cudax_build_compiler_targets)
-  set(cuda_compile_options)
+  set(c_compile_options)
   set(cxx_compile_options)
+  set(cuda_compile_options)
   set(link_options)
   set(cxx_compile_definitions)
 
@@ -50,8 +51,9 @@ function(cudax_build_compiler_targets)
   endif()
 
   cccl_build_compiler_interface(cudax.compiler_interface
-    "${cuda_compile_options}"
+    "${c_compile_options}"
     "${cxx_compile_options}"
+    "${cuda_compile_options}"
     "${link_options}"
     "${cxx_compile_definitions}"
   )

--- a/libcudacxx/cmake/LibcudacxxBuildCompilerTargets.cmake
+++ b/libcudacxx/cmake/LibcudacxxBuildCompilerTargets.cmake
@@ -12,8 +12,9 @@
 #   libcudacxx.compiler_interface and cccl.compiler_interface_cppXX.
 
 function(libcudacxx_build_compiler_targets)
-  set(cuda_compile_options)
+  set(c_compile_options)
   set(cxx_compile_options)
+  set(cuda_compile_options)
   set(link_options)
   set(cxx_compile_definitions)
 
@@ -25,8 +26,9 @@ function(libcudacxx_build_compiler_targets)
   list(APPEND cxx_compile_definitions "CCCL_IGNORE_DEPRECATED_DISCARD_MEMORY_HEADER")
 
   cccl_build_compiler_interface(libcudacxx.compiler_interface
-    "${cuda_compile_options}"
+    "${c_compile_options}"
     "${cxx_compile_options}"
+    "${cuda_compile_options}"
     "${link_options}"
     "${cxx_compile_definitions}"
   )

--- a/libcudacxx/test/libcudacxx/CMakeLists.txt
+++ b/libcudacxx/test/libcudacxx/CMakeLists.txt
@@ -51,6 +51,18 @@ string(APPEND LIBCUDACXX_TEST_COMPILER_FLAGS " -DCCCL_ENABLE_OPTIONAL_REF")
 string(APPEND LIBCUDACXX_TEST_COMPILER_FLAGS " -DCCCL_IGNORE_DEPRECATED_CPP_DIALECT")
 string(APPEND LIBCUDACXX_TEST_COMPILER_FLAGS " -DLIBCUDACXX_IGNORE_DEPRECATED_ABI")
 
+if (CCCL_ENABLE_ASAN)
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+    string(APPEND LIBCUDACXX_TEST_COMPILER_FLAGS
+      " --compiler-options=-fsanitize=address"
+      " --compiler-options=-fno-omit-frame-pointer"
+      " --compiler-options=-fsanitize-address-use-after-scope")
+    string(APPEND LIBCUDACXX_TEST_LINKER_FLAGS " -fsanitize=address")
+  else()
+    message(FATAL_ERROR "CCCL_ENABLE_ASAN is only supported with GCC and Clang, given ${CMAKE_CXX_COMPILER_ID}.")
+  endif()
+endif()
+
 if (NOT MSVC AND NOT ${CMAKE_CUDA_COMPILER_ID} STREQUAL "Clang")
   set(LIBCUDACXX_WARNING_LEVEL "--compiler-options=-Wall --compiler-options=-Wextra")
 endif()

--- a/thrust/cmake/ThrustBuildCompilerTargets.cmake
+++ b/thrust/cmake/ThrustBuildCompilerTargets.cmake
@@ -12,8 +12,9 @@
 #   thrust.compiler_interface and cccl.compiler_interface_cppXX.
 
 function(thrust_build_compiler_targets)
-  set(cuda_compile_options)
+  set(c_compile_options)
   set(cxx_compile_options)
+  set(cuda_compile_options)
   set(link_options)
   set(cxx_compile_definitions)
 
@@ -28,8 +29,9 @@ function(thrust_build_compiler_targets)
   endif()
 
   cccl_build_compiler_interface(thrust.compiler_interface
-    "${cuda_compile_options}"
+    "${c_compile_options}"
     "${cxx_compile_options}"
+    "${cuda_compile_options}"
     "${link_options}"
     "${cxx_compile_definitions}"
   )


### PR DESCRIPTION
## Summary
- Reorder compiler option handling to process C, C++, then CUDA flags
- Emit a status message when AddressSanitizer is enabled and apply flags across languages
- Forward new option order to Cub, CudaX, libcudacxx, Thrust, and add ASAN flags to libcudacxx lit tests

## Testing
- `ci/util/build_and_test_targets.sh --preset cccl-c-parallel --cmake-options "-DCCCL_ENABLE_ASAN=ON"`
- `rg -n -- "-fsanitize=address" build/cccl-c-parallel/build.ninja`
- `ci/util/build_and_test_targets.sh --preset cub-cpp20 --cmake-options "-DCCCL_ENABLE_ASAN=ON"`
- `rg -n -- "-fsanitize=address" build/cub-cpp20/build.ninja`
- `ci/util/build_and_test_targets.sh --preset thrust-cpp20 --cmake-options "-DCCCL_ENABLE_ASAN=ON"`
- `rg -n -- "-fsanitize=address" build/thrust-cpp20/build.ninja`
- `ci/util/build_and_test_targets.sh --preset cudax-cpp20 --cmake-options "-DCCCL_ENABLE_ASAN=ON"`
- `rg -n -- "-fsanitize=address" build/cudax-cpp20/build.ninja`
- `ci/util/build_and_test_targets.sh --preset libcudacxx-cpp20 --cmake-options "-DCCCL_ENABLE_ASAN=ON"`
- `rg -n -- "-fsanitize=address" build/libcudacxx-cpp20/build.ninja`
- `rg -n -- "fsanitize" build/libcudacxx-cpp20/libcudacxx/test/libcudacxx/lit.site.cfg`


------
https://chatgpt.com/codex/tasks/task_e_68b8d37bad8c832bb03339e539b0acd3