### PR TITLE
fix: disable sccache S3 for forked builds

### DIFF
--- a/.github/actions/workflow-run-job-linux/action.yml
+++ b/.github/actions/workflow-run-job-linux/action.yml
@@ -49,6 +49,12 @@ runs:
       shell: bash --noprofile --norc -euo pipefail {0}
       run: |
         echo "::add-matcher::${{github.workspace}}/.github/problem-matchers/problem-matcher.json"
+    - name: Configure sccache
+      shell: bash --noprofile --norc -euo pipefail {0}
+      run: |
+        if [[ "${GITHUB_REPOSITORY}" != "NVIDIA/cccl" ]]; then
+          echo "SCCACHE_S3_NO_CREDENTIALS=true" | tee -a "${GITHUB_ENV}"
+        fi
     - name: Get AWS credentials for sccache bucket
       if: ${{github.repository == 'NVIDIA/cccl'}}
       uses: aws-actions/configure-aws-credentials@v4
@@ -169,7 +175,7 @@ runs:
             "${gpu_request[@]}" \
             --env "AWS_ROLE_ARN=" \
             --env "COMMAND=$COMMAND" \
-            --env "SCCACHE_IDLE_TIMEOUT=0" \
+            --env "SCCACHE_S3_NO_CREDENTIALS=${SCCACHE_S3_NO_CREDENTIALS}" \
             --env "GITHUB_ENV=$GITHUB_ENV" \
             --env "GITHUB_SHA=$GITHUB_SHA" \
             --env "GITHUB_PATH=$GITHUB_PATH" \

--- a/.github/actions/workflow-run-job-windows/action.yml
+++ b/.github/actions/workflow-run-job-windows/action.yml
@@ -15,14 +15,18 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Configure env
+    - name: Configure sccache
       shell: bash --noprofile --norc -euo pipefail {0}
       run: |
         echo "SCCACHE_BUCKET=rapids-sccache-devs" | tee -a "${GITHUB_ENV}"
         echo "SCCACHE_REGION=us-east-2" | tee -a "${GITHUB_ENV}"
         echo "SCCACHE_IDLE_TIMEOUT=0" | tee -a "${GITHUB_ENV}"
         echo "SCCACHE_S3_USE_SSL=true" | tee -a "${GITHUB_ENV}"
-        echo "SCCACHE_S3_NO_CREDENTIALS=false" | tee -a "${GITHUB_ENV}"
+        if [[ "${GITHUB_REPOSITORY}" != "NVIDIA/cccl" ]]; then
+          echo "SCCACHE_S3_NO_CREDENTIALS=true" | tee -a "${GITHUB_ENV}"
+        else
+          echo "SCCACHE_S3_NO_CREDENTIALS=false" | tee -a "${GITHUB_ENV}"
+        fi
     - name: Get AWS credentials for sccache bucket
       if: ${{github.repository == 'NVIDIA/cccl'}}
       uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
## Summary
- avoid sccache credential lookup failures on forks by setting `SCCACHE_S3_NO_CREDENTIALS=true`
- forward only `SCCACHE_S3_NO_CREDENTIALS` into Linux devcontainers
- define full sccache environment for Windows jobs since images lack defaults

## Testing
- `pre-commit run --files .github/actions/workflow-run-job-linux/action.yml .github/actions/workflow-run-job-windows/action.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b8ddd76150832bb3b9978dd199be52