### PR TITLE
Propagate command failures in Windows jobs

### DIFF
--- a/.github/actions/workflow-run-job-windows/action.yml
+++ b/.github/actions/workflow-run-job-windows/action.yml
@@ -65,7 +65,7 @@ runs:
             [System.Environment]::SetEnvironmentVariable('SCCACHE_S3_USE_SSL','${{env.SCCACHE_S3_USE_SSL}}');
             [System.Environment]::SetEnvironmentVariable('SCCACHE_S3_NO_CREDENTIALS','${{env.SCCACHE_S3_NO_CREDENTIALS}}');
             git config --global --add safe.directory '${{steps.paths.outputs.MOUNT_REPO}}';
-            Invoke-Expression \$env:COMMAND"
+            Invoke-Expression \$env:COMMAND; exit \$LASTEXITCODE"
     - name: Prepare job artifacts
       shell: bash --noprofile --norc -euo pipefail {0}
       id: done


### PR DESCRIPTION
## Summary
- exit with command's status when running Windows job command in container to fail job on errors

## Testing
- `pre-commit run --files .github/actions/workflow-run-job-windows/action.yml`


------
https://chatgpt.com/codex/tasks/task_e_68b8f11ddcdc832bb069af7b0a60b1f7