### PR TITLE
Allow CI to run on forks with sccache enabled.

### DIFF
--- a/.devcontainer/docker-entrypoint.sh
+++ b/.devcontainer/docker-entrypoint.sh
@@ -17,7 +17,16 @@ if [ -z "$OLD_UID" ]; then
     exec "$(pwd)/.devcontainer/cccl-entrypoint.sh" "$@";
 elif [ "$OLD_UID" = "$NEW_UID" ] && [ "$OLD_GID" = "$NEW_GID" ]; then
     echo "UIDs and GIDs are the same ($NEW_UID:$NEW_GID).";
-    exec "$(pwd)/.devcontainer/cccl-entrypoint.sh" "$@";
+    # Even when IDs match, ensure we execute as the non-root REMOTE_USER so
+    # gh and sccache use the mapped HOME (/home/coder) where ~/.aws is bind-mounted.
+    export VIRTUAL_ENV=;
+    export VIRTUAL_ENV_PROMPT=;
+    export HOME="$HOME_FOLDER";
+    export XDG_CACHE_HOME="$HOME_FOLDER/.cache";
+    export XDG_CONFIG_HOME="$HOME_FOLDER/.config";
+    export XDG_STATE_HOME="$HOME_FOLDER/.local/state";
+    export PYTHONHISTFILE="$HOME_FOLDER/.local/state/.python_history";
+    exec su -p "$REMOTE_USER" -- "$(pwd)/.devcontainer/cccl-entrypoint.sh" "$@";
 elif [ "$OLD_UID" != "$NEW_UID" ] && [ -n "$EXISTING_USER" ]; then
     echo "User with UID exists ($EXISTING_USER=$NEW_UID).";
     exec "$(pwd)/.devcontainer/cccl-entrypoint.sh" "$@";

--- a/.devcontainer/launch.sh
+++ b/.devcontainer/launch.sh
@@ -180,13 +180,23 @@ launch_docker() {
         ENV_VARS+=("${env_vars[@]}")
     fi
 
-    exec docker run \
-        "${RUN_ARGS[@]}" \
-        "${ENV_VARS[@]}" \
-        "${MOUNTS[@]}" \
-        "${DOCKER_IMAGE}" \
-        "${ENTRYPOINTS[@]}" \
-        "$@"
+    ( # Contain the set -x in a subshell
+        if [[ -n ${GITHUB_ACTIONS:-} ]]; then
+            echo "::group::Docker run command"
+            set -x
+        fi
+        exec docker run \
+          "${RUN_ARGS[@]}" \
+          "${ENV_VARS[@]}" \
+          "${MOUNTS[@]}" \
+          "${DOCKER_IMAGE}" \
+          "${ENTRYPOINTS[@]}" \
+          "$@"
+    )
+
+    if [[ -n ${GITHUB_ACTIONS:-} ]]; then
+        echo "::endgroup::"
+    fi
 }
 
 launch_vscode() {

--- a/.github/actions/workflow-run-job-linux/action.yml
+++ b/.github/actions/workflow-run-job-linux/action.yml
@@ -20,6 +20,13 @@ inputs:
   host:
     description: "The host compiler to use when selecting a devcontainer."
     required: true
+  github_token:
+    description: >-
+      Optional GitHub PAT with at least gist, repo (read), and read:org scopes
+      to enable sccache S3 auth on forks. Typically supplied via the
+      'SCCACHE_AUTH_TOKEN' repository secret in forks.
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -50,6 +57,7 @@ runs:
       run: |
         echo "::add-matcher::${{github.workspace}}/.github/problem-matchers/problem-matcher.json"
     - name: Get AWS credentials for sccache bucket
+      if: ${{ github.repository == 'NVIDIA/cccl' }}
       uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: arn:aws:iam::279114543810:role/gha-oidc-NVIDIA
@@ -81,7 +89,7 @@ runs:
       id: run
       shell: bash --noprofile --norc -euo pipefail {0}
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ inputs.github_token != '' && inputs.github_token || github.token }}
         CI: true
         # Dereferencing the command from an env var instead of a GHA input avoids issues with escaping
         # semicolons and other special characters (e.g. `-arch "60;70;80"`).
@@ -94,6 +102,9 @@ runs:
         #! /usr/bin/env bash
 
         set -euo pipefail
+
+        # Need this for git to trust the docker-mounted workspace:
+        git config --global --add safe.directory "$(pwd)"
 
         echo -e "\e[1;34mRunning as '$(whoami)' user in $(pwd):\e[0m"
         echo -e "\e[1;34mMock with: ci/util/create_mock_job_env.sh $GITHUB_RUN_ID $JOB_ID\e[0m"
@@ -141,11 +152,18 @@ runs:
         chmod 0600 "${aws_dir}/credentials"
         chmod 0664 "${aws_dir}/config"
 
+        # Clear the ARN when using the pre-minted aws creds on the main repo.
+        # Leave this on forks, as they'll need it to authenticate using the
+        # devcontainer-utils scripting via GH_TOKEN.
+        if [[ "$GITHUB_REPOSITORY" == "NVIDIA/cccl" ]]; then
+          set aws_arn="--env AWS_ROLE_ARN="
+        fi
+
         declare -a gpu_request=()
 
         # Explicitly pass which GPU to use if on a GPU runner
         if [[ "${JOB_RUNNER}" = *"-gpu-"* ]]; then
-          gpu_request+=(--gpus "device=${NVIDIA_VISIBLE_DEVICES}")
+          gpu_request+=(--gpus "device=${NVIDIA_VISIBLE_DEVICES:-}")
         fi
 
         # If the image contains "cudaXX.Yext"...
@@ -166,9 +184,11 @@ runs:
             --host $JOB_HOST \
             ${cuda_ext_request:-} \
             "${gpu_request[@]}" \
-            --env "AWS_ROLE_ARN=" \
+            ${aws_arn:-} \
             --env "COMMAND=$COMMAND" \
-            --env "SCCACHE_IDLE_TIMEOUT=0" \
+            --env "CI=true" \
+            --env "SCCACHE_DIST_GH_SCOPES=" \
+            --env "GH_TOKEN=$GH_TOKEN" \
             --env "GITHUB_ENV=$GITHUB_ENV" \
             --env "GITHUB_SHA=$GITHUB_SHA" \
             --env "GITHUB_PATH=$GITHUB_PATH" \
@@ -179,9 +199,8 @@ runs:
             --env "GITHUB_WORKSPACE=$GITHUB_WORKSPACE" \
             --env "GITHUB_REPOSITORY=$GITHUB_REPOSITORY" \
             --env "GITHUB_STEP_SUMMARY=$GITHUB_STEP_SUMMARY" \
-            --env "GH_TOKEN=${{ github.token }}" \
             --env "HOST_WORKSPACE=${{github.workspace}}" \
-            --env "NVIDIA_VISIBLE_DEVICES=$NVIDIA_VISIBLE_DEVICES" \
+            --env "NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:-}" \
             --env "JOB_ID=$JOB_ID" \
             --volume "${ARTIFACT_ARCHIVES}:${ARTIFACT_ARCHIVES}" \
             --volume "${ARTIFACT_UPLOAD_STAGE}:${ARTIFACT_UPLOAD_STAGE}" \

--- a/.github/actions/workflow-run-job-linux/action.yml
+++ b/.github/actions/workflow-run-job-linux/action.yml
@@ -187,7 +187,7 @@ runs:
             ${aws_arn:-} \
             --env "COMMAND=$COMMAND" \
             --env "CI=true" \
-            --env "SCCACHE_DIST_GH_SCOPES=" \
+            --env "SCCACHE_DIST_GH_SCOPES=read:org" \
             --env "GH_TOKEN=$GH_TOKEN" \
             --env "GITHUB_ENV=$GITHUB_ENV" \
             --env "GITHUB_SHA=$GITHUB_SHA" \

--- a/.github/actions/workflow-run-job-windows/action.yml
+++ b/.github/actions/workflow-run-job-windows/action.yml
@@ -11,19 +11,95 @@ inputs:
   image:
     description: "The Docker image to use."
     required: true
+  github_token:
+    description: >-
+      Optional GitHub PAT with at least gist, repo (read), and read:org scopes
+      to enable sccache S3 auth on forks. Typically supplied via the
+      'SCCACHE_AUTH_TOKEN' repository secret in forks.
+    required: false
+    default: ""
 
 runs:
   using: "composite"
   steps:
-    - name: Configure env
+    - name: Mint S3 creds for sccache (forks with PAT)
+      id: mint
+      if: ${{ github.repository != 'NVIDIA/cccl' && inputs.github_token != '' }}
+      shell: bash --noprofile --norc -euo pipefail {0}
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
+      run: |
+        echo "minted=false" >> "$GITHUB_OUTPUT"
+        if ! command -v gh >/dev/null 2>&1; then
+          echo "::notice::gh CLI not found; will use local sccache."
+          exit 0
+        fi
+        # Ensure gh is authenticated with the provided token
+        if ! gh auth status >/dev/null 2>&1; then
+          printf '%s' "$GH_TOKEN" | gh auth login --with-token >/dev/null 2>&1 || true
+        fi
+        # Install nv-gha-aws if not already installed
+        if ! gh nv-gha-aws --help >/dev/null 2>&1;
+        then
+          gh extension install nv-gha-runners/gh-nv-gha-aws || :
+        fi
+        if gh nv-gha-aws --help >/dev/null 2>&1; then
+          for org in nvidia rapids nv-legate nv-morpheus; do
+            if gh nv-gha-aws org "$org" \
+                 --output shell \
+                 --role-arn 'arn:aws:iam::279114543810:role/nv-gha-token-sccache-devs' \
+                 > aws.env 2>/dev/null; then
+              break
+            fi
+          done
+        fi
+        if [[ -s aws.env ]]; then
+          source aws.env
+
+          printf '::add-mask::%s\n' "$AWS_ACCESS_KEY_ID"
+          printf '::add-mask::%s\n' "$AWS_SECRET_ACCESS_KEY"
+          printf '::add-mask::%s\n' "$AWS_SESSION_TOKEN"
+
+          {
+            printf 'AWS_ACCESS_KEY_ID=%s\n' "$AWS_ACCESS_KEY_ID"
+            printf 'AWS_SECRET_ACCESS_KEY=%s\n' "$AWS_SECRET_ACCESS_KEY"
+            printf 'AWS_SESSION_TOKEN=%s\n' "$AWS_SESSION_TOKEN"
+            printf 'SCCACHE_S3_NO_CREDENTIALS=false\n'
+          } >> "$GITHUB_ENV"
+
+          echo "Minted AWS credentials for sccache."
+          echo "minted=true" | tee -a "$GITHUB_OUTPUT"
+
+          rm -f aws.env || :
+        else
+          echo "::warning::Failed to mint AWS credentials for sccache; will use local sccache."
+          echo "minted=false" | tee -a "$GITHUB_OUTPUT"
+        fi
+    - name: Configure sccache
       shell: bash --noprofile --norc -euo pipefail {0}
       run: |
-        echo "SCCACHE_BUCKET=rapids-sccache-devs" | tee -a "${GITHUB_ENV}"
-        echo "SCCACHE_REGION=us-east-2" | tee -a "${GITHUB_ENV}"
         echo "SCCACHE_IDLE_TIMEOUT=0" | tee -a "${GITHUB_ENV}"
         echo "SCCACHE_S3_USE_SSL=true" | tee -a "${GITHUB_ENV}"
-        echo "SCCACHE_S3_NO_CREDENTIALS=false" | tee -a "${GITHUB_ENV}"
+
+        if [[ "${{ github.repository }}" == "NVIDIA/cccl" || "${{ steps.mint.outputs.minted }}" == "true" ]]; then
+          # Enable remote cache: set bucket/region and clear NO_CREDENTIALS
+          echo "SCCACHE_BUCKET=rapids-sccache-devs" | tee -a "${GITHUB_ENV}"
+          echo "SCCACHE_REGION=us-east-2" | tee -a "${GITHUB_ENV}"
+          echo "SCCACHE_S3_NO_CREDENTIALS=false" | tee -a "${GITHUB_ENV}"
+        else
+          # Force local cache: clear bucket/region and set NO_CREDENTIALS
+          echo "SCCACHE_BUCKET=" | tee -a "${GITHUB_ENV}"
+          echo "SCCACHE_REGION=" | tee -a "${GITHUB_ENV}"
+          echo "SCCACHE_S3_NO_CREDENTIALS=true" | tee -a "${GITHUB_ENV}"
+
+          echo "::warning::sccache remote cache is disabled; AWS credentials could not be minted."
+          echo "::warning::To enable sccache on a fork, create a GitHub PAT with gist, repo, and read:org scopes,"
+          echo "::warning::then add it as an Actions secret named 'SCCACHE_AUTH_TOKEN' in your fork"
+          echo "::warning::(Settings > Secrets and variables > Actions). The workflow will use it automatically."
+
+        fi
     - name: Get AWS credentials for sccache bucket
+      if: ${{ github.repository == 'NVIDIA/cccl' }}
       uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: arn:aws:iam::279114543810:role/gha-oidc-NVIDIA
@@ -43,15 +119,20 @@ runs:
       run: |
         echo "HOST_REPO=${{ github.workspace }}\${{ github.event.repository.name }}".Replace('\', '/') | Out-File -FilePath $env:GITHUB_OUTPUT -Append
         echo "MOUNT_REPO=C:/${{ github.event.repository.name }}" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-        cat $env:GITHUB_OUTPUT
     - name: Run command # Do not change this step's name, it is checked in parse-job-times.py
       shell: bash --noprofile --norc -euo pipefail {0}
+      env:
+        GH_TOKEN: ${{ inputs.github_token != '' && inputs.github_token || github.token }}
       run: |
         docker run \
           --mount type=bind,source="${{steps.paths.outputs.HOST_REPO}}",target="${{steps.paths.outputs.MOUNT_REPO}}" \
           --workdir "${{steps.paths.outputs.MOUNT_REPO}}" \
           --isolation=process \
           --env COMMAND='& ${{inputs.command}}' \
+          --env GITHUB_REPOSITORY="$GITHUB_REPOSITORY" \
+          --env CI=true \
+          --env SCCACHE_DIST_GH_SCOPES= \
+          --env GH_TOKEN=${GH_TOKEN} \
           ${{ inputs.image }} \
           powershell -c "
             [System.Environment]::SetEnvironmentVariable('AWS_ACCESS_KEY_ID','${{env.AWS_ACCESS_KEY_ID}}');
@@ -63,7 +144,7 @@ runs:
             [System.Environment]::SetEnvironmentVariable('SCCACHE_S3_USE_SSL','${{env.SCCACHE_S3_USE_SSL}}');
             [System.Environment]::SetEnvironmentVariable('SCCACHE_S3_NO_CREDENTIALS','${{env.SCCACHE_S3_NO_CREDENTIALS}}');
             git config --global --add safe.directory '${{steps.paths.outputs.MOUNT_REPO}}';
-            Invoke-Expression \$env:COMMAND"
+            Invoke-Expression \$env:COMMAND; exit \$LASTEXITCODE"
     - name: Prepare job artifacts
       shell: bash --noprofile --norc -euo pipefail {0}
       id: done

--- a/.github/actions/workflow-run-job-windows/action.yml
+++ b/.github/actions/workflow-run-job-windows/action.yml
@@ -131,7 +131,7 @@ runs:
           --env COMMAND='& ${{inputs.command}}' \
           --env GITHUB_REPOSITORY="$GITHUB_REPOSITORY" \
           --env CI=true \
-          --env SCCACHE_DIST_GH_SCOPES= \
+          --env SCCACHE_DIST_GH_SCOPES=read:org \
           --env GH_TOKEN=${GH_TOKEN} \
           ${{ inputs.image }} \
           powershell -c "

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -45,7 +45,7 @@ concurrency:
 jobs:
   # Build and deploy job
   build-and-deploy:
-    runs-on: linux-amd64-cpu32
+    runs-on: ${{ github.repository == 'NVIDIA/cccl' && 'linux-amd64-cpu32' || 'ubuntu-latest' }}
     outputs:
       preview_url: ${{ steps.set-preview-url.outputs.preview_url }}
     steps:

--- a/.github/workflows/build-matx.yml
+++ b/.github/workflows/build-matx.yml
@@ -39,7 +39,7 @@ on:
 jobs:
   build-matx:
     name: Build MatX
-    runs-on: linux-amd64-cpu32
+    runs-on: ${{ github.repository == 'NVIDIA/cccl' && 'linux-amd64-cpu32' || 'ubuntu-latest' }}
     permissions:
       id-token: write
       contents: read
@@ -52,6 +52,7 @@ jobs:
       - name: Add NVCC problem matcher
         run: echo "::add-matcher::$(pwd)/.github/problem-matchers/problem-matcher.json"
       - uses: aws-actions/configure-aws-credentials@v4
+        if: ${{ github.repository == 'NVIDIA/cccl' }}
         with:
           role-to-assume: arn:aws:iam::279114543810:role/gha-oidc-NVIDIA
           aws-region: us-east-2
@@ -81,9 +82,9 @@ jobs:
 
           cat <<EOF > .aws/credentials
           [default]
-          aws_access_key_id=$AWS_ACCESS_KEY_ID
-          aws_session_token=$AWS_SESSION_TOKEN
-          aws_secret_access_key=$AWS_SECRET_ACCESS_KEY
+          aws_access_key_id=${AWS_ACCESS_KEY_ID:-}
+          aws_session_token=${AWS_SESSION_TOKEN:-}
+          aws_secret_access_key=${AWS_SECRET_ACCESS_KEY:-}
           EOF
 
           chmod 0600 .aws/credentials

--- a/.github/workflows/build-rapids.yml
+++ b/.github/workflows/build-rapids.yml
@@ -78,6 +78,7 @@ jobs:
       - name: Add NVCC problem matcher
         run: echo "::add-matcher::$(pwd)/.github/problem-matchers/problem-matcher.json"
       - uses: aws-actions/configure-aws-credentials@v4
+        if: ${{ github.repository == 'NVIDIA/cccl' }}
         with:
           role-to-assume: arn:aws:iam::279114543810:role/gha-oidc-NVIDIA
           aws-region: us-east-2
@@ -178,11 +179,13 @@ jobs:
             --env "CCCL_TAG=${CCCL_TAG}" \
             --env "CCCL_VERSION=${CCCL_VERSION}" \
             --env "AWS_ROLE_ARN=" \
-            --env "AWS_REGION=$AWS_REGION" \
-            --env "SCCACHE_REGION=$AWS_REGION" \
-            --env "AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID" \
-            --env "AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN" \
-            --env "AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY" \
+            --env "AWS_REGION=${AWS_REGION:-}" \
+            --env "SCCACHE_BUCKET=${SCCACHE_BUCKET:-}" \
+            --env "SCCACHE_REGION=${SCCACHE_REGION:-}" \
+            --env "SCCACHE_S3_NO_CREDENTIALS=${SCCACHE_S3_NO_CREDENTIALS:-}" \
+            --env "AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}" \
+            --env "AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN:-}" \
+            --env "AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}" \
             --env "GITHUB_ACTIONS=$GITHUB_ACTIONS" \
             --env "GITHUB_SHA=$GITHUB_SHA" \
             --env "GITHUB_REF_NAME=$GITHUB_REF_NAME" \

--- a/.github/workflows/ci-workflow-pull-request.yml
+++ b/.github/workflows/ci-workflow-pull-request.yml
@@ -24,6 +24,7 @@ on:
   push:
     branches:
       - "pull-request/[0-9]+"
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-on-${{ github.event_name }}-from-${{ github.ref_name }}
@@ -32,6 +33,13 @@ concurrency:
 jobs:
   build-workflow:
     name: Build workflow from matrix
+    # On NVIDIA/cccl, run when pushed to a copy-pr-bot branch.
+    # On forks, run when a pull request is opened:
+    if: >-
+      ${{
+        (github.repository == 'NVIDIA/cccl' && github.event_name == 'push') ||
+        (github.repository != 'NVIDIA/cccl' && github.event_name == 'pull_request')
+      }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -40,7 +48,25 @@ jobs:
       base_sha: ${{ steps.export-pr-info.outputs.base_sha }}
       pr_number: ${{ steps.export-pr-info.outputs.pr_number }}
       workflow: ${{ steps.build-workflow.outputs.workflow }}
+      ci_enabled: ${{ steps.export-flags.outputs.ci_enabled }}
+      matrix_enabled: ${{ steps.export-flags.outputs.matrix_enabled }}
+      vdc_enabled: ${{ steps.export-flags.outputs.vdc_enabled }}
+      docs_enabled: ${{ steps.export-flags.outputs.docs_enabled }}
+      rapids_enabled: ${{ steps.export-flags.outputs.rapids_enabled }}
+      matx_enabled: ${{ steps.export-flags.outputs.matx_enabled }}
     steps:
+      - name: Export workflow flags
+        id: export-flags
+        run: |
+          output() { echo "$1=$2" | tee -a "${GITHUB_OUTPUT}"; }
+
+          output ci_enabled     "true" # This job only runs when CI is enabled (see `if:` field)
+          output matrix_enabled "${{ !contains(github.event.head_commit.message, '[skip-matrix]') }}"
+          output vdc_enabled    "${{ !contains(github.event.head_commit.message, '[skip-vdc]') }}"
+          output docs_enabled   "${{ !contains(github.event.head_commit.message, '[skip-docs]') }}"
+          output rapids_enabled "${{  contains(github.event.head_commit.message, '[test-rapids]') }}"
+          # MatX build OOMs the public github runners used on forks:
+          output matx_enabled   "${{ !contains(github.event.head_commit.message, '[skip-matx]') && github.repository == 'NVIDIA/cccl' }}"
       - name: Checkout repo
         uses: actions/checkout@v4
         with:
@@ -54,27 +80,26 @@ jobs:
           echo "base_sha=${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.sha }}" | tee -a "${GITHUB_OUTPUT}"
           echo "pr_number=${{ fromJSON(steps.get-pr-info.outputs.pr-info).number }}" | tee -a "${GITHUB_OUTPUT}"
       - name: Build workflow
-        if: ${{ !contains(github.event.head_commit.message, '[skip-matrix]') }}
+        # Skip building the matrix when disabled, but still gather PR info for downstream jobs
+        if: steps.export-flags.outputs.matrix_enabled == 'true'
         id: build-workflow
         uses: ./.github/actions/workflow-build
-        env:
-          pr_worflow: ${{ !contains(github.event.head_commit.message, '[workflow:!pull_request]') && 'pull_request' || '' }}
-          nightly_workflow: ${{ contains(github.event.head_commit.message, '[workflow:nightly]') && 'nightly' || '' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           pr_number: ${{ steps.export-pr-info.outputs.pr_number }}
           allow_override: "true"
-          inspect_changes_script: ${{ toJSON(!contains(github.event.head_commit.message, '[all-projects]') && 'ci/inspect_changes.sh' || '') }}
+          inspect_changes_script: 'ci/inspect_changes.sh'
           inspect_changes_base_sha: ${{ steps.export-pr-info.outputs.base_sha }}
-          workflows: >-
-            ${{ env.pr_worflow }}
-            ${{ env.nightly_workflow }}
+          workflows: ${{ github.repository == 'NVIDIA/cccl' && 'pull_request' || 'pull_request_fork' }}
 
   dispatch-groups-linux-two-stage:
     name: ${{ matrix.name }}
     if: >-
-      ${{ !contains(github.event.head_commit.message, '[skip-matrix]') &&
-          toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_two_stage']['keys']) != '[]' }}
+      ${{
+        needs.build-workflow.outputs.ci_enabled == 'true' &&
+        needs.build-workflow.outputs.matrix_enabled == 'true' &&
+        toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_two_stage']['keys']) != '[]'
+      }}
     needs: build-workflow
     permissions:
       id-token: write
@@ -86,12 +111,16 @@ jobs:
     uses: ./.github/workflows/workflow-dispatch-two-stage-group-linux.yml
     with:
       pc-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_two_stage']['jobs'][matrix.name]) }}
+    secrets: inherit
 
   dispatch-groups-windows-two-stage:
     name: ${{ matrix.name }}
     if: >-
-      ${{ !contains(github.event.head_commit.message, '[skip-matrix]') &&
-          toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_two_stage']['keys']) != '[]' }}
+      ${{
+        needs.build-workflow.outputs.ci_enabled == 'true' &&
+        needs.build-workflow.outputs.matrix_enabled == 'true' &&
+        toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_two_stage']['keys']) != '[]'
+      }}
     needs: build-workflow
     permissions:
       id-token: write
@@ -103,12 +132,16 @@ jobs:
     uses: ./.github/workflows/workflow-dispatch-two-stage-group-windows.yml
     with:
       pc-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_two_stage']['jobs'][matrix.name]) }}
+    secrets: inherit
 
   dispatch-groups-linux-standalone:
     name: ${{ matrix.name }}
     if: >-
-      ${{ !contains(github.event.head_commit.message, '[skip-matrix]') &&
-          toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_standalone']['keys']) != '[]' }}
+      ${{
+        needs.build-workflow.outputs.ci_enabled == 'true' &&
+        needs.build-workflow.outputs.matrix_enabled == 'true' &&
+        toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_standalone']['keys']) != '[]'
+      }}
     needs: build-workflow
     permissions:
       id-token: write
@@ -120,12 +153,16 @@ jobs:
     uses: ./.github/workflows/workflow-dispatch-standalone-group-linux.yml
     with:
       job-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_standalone']['jobs'][matrix.name]) }}
+    secrets: inherit
 
   dispatch-groups-windows-standalone:
     name: ${{ matrix.name }}
     if: >-
-      ${{ !contains(github.event.head_commit.message, '[skip-matrix]') &&
-          toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_standalone']['keys']) != '[]' }}
+      ${{
+        needs.build-workflow.outputs.ci_enabled == 'true' &&
+        needs.build-workflow.outputs.matrix_enabled == 'true' &&
+        toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_standalone']['keys']) != '[]'
+      }}
     needs: build-workflow
     permissions:
       id-token: write
@@ -137,10 +174,17 @@ jobs:
     uses: ./.github/workflows/workflow-dispatch-standalone-group-windows.yml
     with:
       job-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_standalone']['jobs'][matrix.name]) }}
+    secrets: inherit
 
   verify-workflow:
     name: Verify and summarize workflow results
-    if: ${{ always() && !cancelled() && !contains(github.event.head_commit.message, '[skip-matrix]') }}
+    if: >-
+      ${{
+        needs.build-workflow.outputs.ci_enabled == 'true' &&
+        always() &&
+        !cancelled() &&
+        needs.build-workflow.outputs.matrix_enabled == 'true'
+      }}
     needs:
       - build-workflow
       - dispatch-groups-linux-two-stage
@@ -166,8 +210,12 @@ jobs:
 
   verify-devcontainers:
     name: Verify Dev Containers
-    if: ${{ !contains(github.event.head_commit.message, '[skip-vdc]') }}
     needs: build-workflow
+    if: >-
+      ${{
+        needs.build-workflow.outputs.ci_enabled == 'true' &&
+        needs.build-workflow.outputs.vdc_enabled == 'true'
+      }}
     permissions:
       id-token: write
       contents: read
@@ -177,8 +225,13 @@ jobs:
 
   docs-build:
     name: Build and deploy documentation preview
-    if: ${{ needs.build-workflow.outputs.pr_number && !contains(github.event.head_commit.message, '[skip-docs]') }}
     needs: build-workflow
+    if: >-
+      ${{
+        needs.build-workflow.outputs.pr_number &&
+        needs.build-workflow.outputs.ci_enabled  == 'true' &&
+        needs.build-workflow.outputs.docs_enabled == 'true'
+      }}
     permissions:
       contents: write
       pull-requests: write
@@ -190,7 +243,12 @@ jobs:
 
   build-rapids:
     name: Build RAPIDS (optional)
-    if: ${{ contains(github.event.head_commit.message, '[test-rapids]') }}
+    needs: build-workflow
+    if: >-
+      ${{
+        needs.build-workflow.outputs.ci_enabled   == 'true' &&
+        needs.build-workflow.outputs.rapids_enabled == 'true'
+      }}
     secrets: inherit
     permissions:
       actions: read
@@ -202,7 +260,12 @@ jobs:
 
   build-matx:
     name: Build MatX (optional)
-    if: ${{ !contains(github.event.head_commit.message, '[skip-matx]') }}
+    needs: build-workflow
+    if: >-
+      ${{
+        needs.build-workflow.outputs.ci_enabled  == 'true' &&
+        needs.build-workflow.outputs.matx_enabled == 'true'
+      }}
     secrets: inherit
     permissions:
       id-token: write
@@ -216,8 +279,14 @@ jobs:
     # !! Need to use always() instead of !cancelled() because skipped jobs count as success
     # !! for Github branch protection checks. Yes, really: by default, branch protections
     # !! can be bypassed by cancelling CI. See NVIDIA/cccl#605.
-    if: ${{ always() }}
+    if: >-
+      ${{
+        github.repository == 'NVIDIA/cccl' &&
+        needs.build-workflow.outputs.ci_enabled == 'true' &&
+        always()
+      }}
     needs:
+      - build-workflow
       - verify-workflow
       - verify-devcontainers
       - docs-build

--- a/.github/workflows/project_automation_set_in_progress.yml
+++ b/.github/workflows/project_automation_set_in_progress.yml
@@ -42,6 +42,7 @@ env:
 
 jobs:
   query_and_mutate_project_fields:
+    if: github.repository == 'NVIDIA/cccl'
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/project_automation_set_in_review.yml
+++ b/.github/workflows/project_automation_set_in_review.yml
@@ -35,6 +35,7 @@ env:
 
 jobs:
   query_and_mutate_project_fields:
+    if: github.repository == 'NVIDIA/cccl'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/project_automation_set_issue_type.yml
+++ b/.github/workflows/project_automation_set_issue_type.yml
@@ -36,6 +36,7 @@ env:
 
 jobs:
   update_issue_type_in_project:
+    if: github.repository == 'NVIDIA/cccl'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/project_automation_set_roadmap.yml
+++ b/.github/workflows/project_automation_set_roadmap.yml
@@ -37,6 +37,7 @@ env:
 
 jobs:
   set_roadmap_value:
+    if: github.repository == 'NVIDIA/cccl'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/project_automation_sync_pr_issues.yml
+++ b/.github/workflows/project_automation_sync_pr_issues.yml
@@ -35,6 +35,7 @@ env:
 
 jobs:
   query_and_mutate_project_fields:
+    if: github.repository == 'NVIDIA/cccl'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/verify-devcontainers.yml
+++ b/.github/workflows/verify-devcontainers.yml
@@ -96,8 +96,13 @@ jobs:
   verify-devcontainers:
     name: ${{matrix.devcontainer.name}}
     needs: get-devcontainer-list
-    if: ${{ needs.get-devcontainer-list.outputs.skip != 'true' }}
-    runs-on: linux-amd64-cpu4
+    # Stop here on forks -- these jobs can OOM public runners.
+    if: >-
+      ${{
+        github.repository == 'NVIDIA/cccl' &&
+        needs.get-devcontainer-list.outputs.skip != 'true'
+      }}
+    runs-on: 'linux-amd64-cpu4'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/workflow-dispatch-standalone-group-linux.yml
+++ b/.github/workflows/workflow-dispatch-standalone-group-linux.yml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ github.repository == 'NVIDIA/cccl' && matrix.runner || 'ubuntu-latest' }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -37,3 +37,4 @@ jobs:
           runner:  ${{ matrix.runner }}
           cuda:    ${{ matrix.cuda }}
           host:    ${{ matrix.host }}
+          github_token: ${{ github.repository != 'NVIDIA/cccl' && secrets.SCCACHE_AUTH_TOKEN || '' }}

--- a/.github/workflows/workflow-dispatch-standalone-group-windows.yml
+++ b/.github/workflows/workflow-dispatch-standalone-group-windows.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   run-jobs:
     name: ${{ matrix.name }}
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ github.repository == 'NVIDIA/cccl' && matrix.runner || 'windows-latest' }}
     permissions:
       id-token: write
       contents: read
@@ -34,3 +34,4 @@ jobs:
           id:      ${{ matrix.id }}
           command: ${{ matrix.command }}
           image:   ${{ matrix.image }}
+          github_token: ${{ github.repository != 'NVIDIA/cccl' && secrets.SCCACHE_AUTH_TOKEN || '' }}

--- a/.github/workflows/workflow-dispatch-two-stage-group-linux.yml
+++ b/.github/workflows/workflow-dispatch-two-stage-group-linux.yml
@@ -26,3 +26,4 @@ jobs:
     with:
       producers: ${{ toJSON(matrix.producers) }}
       consumers: ${{ toJSON(matrix.consumers) }}
+    secrets: inherit

--- a/.github/workflows/workflow-dispatch-two-stage-group-windows.yml
+++ b/.github/workflows/workflow-dispatch-two-stage-group-windows.yml
@@ -26,3 +26,4 @@ jobs:
     with:
       producers: ${{ toJSON(matrix.producers) }}
       consumers: ${{ toJSON(matrix.consumers) }}
+    secrets: inherit

--- a/.github/workflows/workflow-dispatch-two-stage-linux.yml
+++ b/.github/workflows/workflow-dispatch-two-stage-linux.yml
@@ -21,7 +21,7 @@ jobs:
   # The build-workflow.py script will emit an error if more than one producer is specified.
   producer:
     name: ${{ fromJSON(inputs.producers)[0].name }}
-    runs-on: ${{ fromJSON(inputs.producers)[0].runner }}
+    runs-on: ${{ github.repository == 'NVIDIA/cccl' && fromJSON(inputs.producers)[0].runner || 'ubuntu-latest' }}
     permissions:
       id-token: write
       contents: read
@@ -39,11 +39,12 @@ jobs:
           runner:  ${{ fromJSON(inputs.producers)[0].runner }}
           cuda:    ${{ fromJSON(inputs.producers)[0].cuda }}
           host:    ${{ fromJSON(inputs.producers)[0].host }}
+          github_token: ${{ github.repository != 'NVIDIA/cccl' && secrets.SCCACHE_AUTH_TOKEN || '' }}
 
   consumers:
     name: "${{ matrix.name }}"
     needs: producer
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ github.repository == 'NVIDIA/cccl' && matrix.runner || 'ubuntu-latest' }}
     permissions:
       id-token: write
       contents: read
@@ -65,3 +66,4 @@ jobs:
           runner:  ${{ matrix.runner }}
           cuda:    ${{ matrix.cuda }}
           host:    ${{ matrix.host }}
+          github_token: ${{ github.repository != 'NVIDIA/cccl' && secrets.SCCACHE_AUTH_TOKEN || '' }}

--- a/.github/workflows/workflow-dispatch-two-stage-windows.yml
+++ b/.github/workflows/workflow-dispatch-two-stage-windows.yml
@@ -21,7 +21,7 @@ jobs:
   # The build-workflow.py script will emit an error if more than one producer is specified.
   producer:
     name: ${{ fromJSON(inputs.producers)[0].name }}
-    runs-on: ${{ fromJSON(inputs.producers)[0].runner }}
+    runs-on: ${{ github.repository == 'NVIDIA/cccl' && fromJSON(inputs.producers)[0].runner || 'windows-latest' }}
     permissions:
       id-token: write
       contents: read
@@ -36,11 +36,12 @@ jobs:
           id:      ${{ fromJSON(inputs.producers)[0].id }}
           command: ${{ fromJSON(inputs.producers)[0].command }}
           image:   ${{ fromJSON(inputs.producers)[0].image }}
+          github_token: ${{ github.repository != 'NVIDIA/cccl' && secrets.SCCACHE_AUTH_TOKEN || '' }}
 
   consumers:
     name: ${{ matrix.name }}
     needs: producer
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ github.repository == 'NVIDIA/cccl' && matrix.runner || 'windows-latest' }}
     permissions:
       id-token: write
       contents: read
@@ -59,3 +60,4 @@ jobs:
           id:      ${{ matrix.id }}
           command: ${{ matrix.command }}
           image:   ${{ matrix.image }}
+          github_token: ${{ github.repository != 'NVIDIA/cccl' && secrets.SCCACHE_AUTH_TOKEN || '' }}

--- a/ci/build_cuda_cccl_python.sh
+++ b/ci/build_cuda_cccl_python.sh
@@ -36,37 +36,39 @@ fi
 # We build separate wheels using separate containers for each CUDA version,
 # then merge them into a single wheel.
 
+readonly cuda12_version=12.9.1
+readonly cuda13_version=13.0.0
+readonly devcontainer_version=25.10
+readonly devcontainer_distro=rockylinux8
+
+readonly cuda12_image=rapidsai/ci-wheel:${devcontainer_version}-cuda${cuda12_version}-${devcontainer_distro}-py${py_version}
+readonly cuda13_image=rapidsai/ci-wheel:${devcontainer_version}-cuda${cuda13_version}-${devcontainer_distro}-py${py_version}
+
 mkdir -p wheelhouse
 
-echo "Building CUDA 12 wheel..."
-(
-  set -x
-  docker run --rm -i \
-      --workdir /workspace/python/cuda_cccl \
-      --mount type=bind,source=${HOST_WORKSPACE},target=/workspace/ \
-      ${action_mounts} \
-      --env py_version=${py_version} \
-      --env GITHUB_ACTIONS=${GITHUB_ACTIONS:-} \
-      --env GITHUB_RUN_ID=${GITHUB_RUN_ID:-} \
-      --env JOB_ID=${JOB_ID:-} \
-      rapidsai/ci-wheel:25.10-cuda12.9.1-rockylinux8-py${py_version} \
-      /workspace/ci/build_cuda_cccl_wheel.sh
-)
-
-echo "Building CUDA 13 wheel..."
-(
-  set -x
-  docker run --rm -i \
-      --workdir /workspace/python/cuda_cccl \
-      --mount type=bind,source=${HOST_WORKSPACE},target=/workspace/ \
-      ${action_mounts} \
-      --env py_version=${py_version} \
-      --env GITHUB_ACTIONS=${GITHUB_ACTIONS:-} \
-      --env GITHUB_RUN_ID=${GITHUB_RUN_ID:-} \
-      --env JOB_ID=${JOB_ID:-} \
-      rapidsai/ci-wheel:25.10-cuda13.0.0-rockylinux8-py${py_version} \
-      /workspace/ci/build_cuda_cccl_wheel.sh
-)
+for ctk in 12 13; do
+  image=$(eval echo \$cuda${ctk}_image)
+  echo "::group::⚒️ Building CUDA ${ctk} wheel on ${image}"
+  (
+    set -x
+    docker pull $image
+    docker run --rm -i \
+        --workdir /workspace/python/cuda_cccl \
+        --mount type=bind,source=${HOST_WORKSPACE},target=/workspace/ \
+        ${action_mounts} \
+        --env py_version=${py_version} \
+        --env GITHUB_ACTIONS=${GITHUB_ACTIONS:-} \
+        --env GITHUB_RUN_ID=${GITHUB_RUN_ID:-} \
+        --env JOB_ID=${JOB_ID:-} \
+        $image \
+        /workspace/ci/build_cuda_cccl_wheel.sh
+    # Prevent GHA runners from exhausting available storage with leftover images:
+    if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+      docker rmi -f $image
+    fi
+  )
+  echo "::endgroup::"
+done
 
 echo "Merging CUDA wheels..."
 

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -67,6 +67,18 @@ workflows:
     # - CTK 13.X unsupported: https://gitlab.kitware.com/cmake/cmake/-/merge_requests/11079#note_1692019
     # - {jobs: ['build'], cudacxx: 'clang', ctk: '13.X', std: 'all', cxx: 'clang', sm: '75;80'}
 
+  pull_request_fork:
+    # Runs on public github runners.
+    # Minimal single arch configs on current compilers to reduce expense. No GPUs available.
+    - {jobs: ['build'],          project: 'libcudacxx',      std: 'max', cxx: ['gcc', 'clang', 'msvc'], sm: '80'}
+    - {jobs: ['test_cpu'],       project: 'thrust',          std: 'max', cxx: ['gcc', 'clang', 'msvc'], sm: '80'}
+    - {jobs: ['build'],          project: 'cub',             std: 'max', cxx: ['gcc', 'clang', 'msvc'], sm: '80'}
+    - {jobs: ['build'],          project: 'cudax',           std: 'max', cxx: ['gcc', 'clang', 'msvc'], sm: '80'}
+    - {jobs: ['verify_codegen'], project: 'libcudacxx'}
+    # Pinned to gcc13:
+    - {jobs: ['build'],          project: 'cccl_c_parallel', cxx: 'gcc13', sm: '80'}
+    - {jobs: ['build'],          project: 'python',          cxx: 'gcc13', py_version: '3.13', sm: '80'}
+
   nightly:
     # CTK 12.0 full matrix build: default projects
     - {jobs: ['build'], std: 'all', ctk: '12.0', cxx: ['gcc7', 'gcc8', 'gcc9', 'gcc10', 'gcc11', 'gcc12']}


### PR DESCRIPTION
Adds a minimal 'pull_request_fork' workflow that can be launched on github public runners.
This workflow will automatically run when a pull request is opened or updated *on a fork* of CCCL. It will not run CI automatically on every push, and the copy-pr-bot logic remains in place on the main repo.

The python wheel builder was updated to remove the temporary docker images after it is done with them, as they were exhausting the available storage on github runners.