### PR TITLE
ci: allow forks to configure remote sccache

### DIFF
--- a/.github/actions/workflow-run-job-linux/action.yml
+++ b/.github/actions/workflow-run-job-linux/action.yml
@@ -56,6 +56,18 @@ runs:
         role-to-assume: arn:aws:iam::279114543810:role/gha-oidc-NVIDIA
         aws-region: us-east-2
         role-duration-seconds: 43200 # 12 hours
+    - name: Configure fork GitHub token for sccache
+      if: ${{ github.repository != 'NVIDIA/cccl' }}
+      shell: bash --noprofile --norc -euo pipefail {0}
+      env:
+        FORK_GH_TOKEN: ${{ secrets.SCCACHE_AUTH_TOKEN }}
+      run: |
+        if [[ -n "${FORK_GH_TOKEN}" ]]; then
+          echo "GITHUB_TOKEN=${FORK_GH_TOKEN}" | tee -a "$GITHUB_ENV"
+        else
+          echo "::warning::sccache remote cache is disabled for forks by default."
+          echo "::warning::Create a GitHub PAT with gist, repo, read:org scopes and add it as the GITHUB_TOKEN secret to enable remote sccache."
+        fi
     - name: Print CI override matrix job def
       env:
         GH_TOKEN: ${{ github.token }}
@@ -180,6 +192,7 @@ runs:
             --env "GITHUB_REPOSITORY=$GITHUB_REPOSITORY" \
             --env "GITHUB_STEP_SUMMARY=$GITHUB_STEP_SUMMARY" \
             --env "GH_TOKEN=${{ github.token }}" \
+            --env "GITHUB_TOKEN=${GITHUB_TOKEN:-}" \
             --env "HOST_WORKSPACE=${{github.workspace}}" \
             --env "NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:-}" \
             --env "JOB_ID=$JOB_ID" \

--- a/.github/actions/workflow-run-job-windows/action.yml
+++ b/.github/actions/workflow-run-job-windows/action.yml
@@ -17,12 +17,20 @@ runs:
   steps:
     - name: Configure sccache
       shell: bash --noprofile --norc -euo pipefail {0}
+      env:
+        FORK_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        echo "SCCACHE_BUCKET=rapids-sccache-devs" | tee -a "${GITHUB_ENV}"
-        echo "SCCACHE_REGION=us-east-2" | tee -a "${GITHUB_ENV}"
-        echo "SCCACHE_IDLE_TIMEOUT=0" | tee -a "${GITHUB_ENV}"
-        echo "SCCACHE_S3_USE_SSL=true" | tee -a "${GITHUB_ENV}"
-        echo "SCCACHE_S3_NO_CREDENTIALS=false" | tee -a "${GITHUB_ENV}"
+        if [[ "${{ github.repository }}" == "NVIDIA/cccl" || -n "${FORK_GH_TOKEN}" ]]; then
+          echo "SCCACHE_BUCKET=rapids-sccache-devs" | tee -a "${GITHUB_ENV}"
+          echo "SCCACHE_REGION=us-east-2" | tee -a "${GITHUB_ENV}"
+          echo "SCCACHE_IDLE_TIMEOUT=0" | tee -a "${GITHUB_ENV}"
+          echo "SCCACHE_S3_USE_SSL=true" | tee -a "${GITHUB_ENV}"
+          echo "SCCACHE_S3_NO_CREDENTIALS=false" | tee -a "${GITHUB_ENV}"
+        else
+          echo "::warning::sccache remote cache is disabled for forks by default."
+          echo "::warning::Create a GitHub PAT with gist, repo, read:org scopes and add it as the GITHUB_TOKEN secret to enable remote sccache."
+          echo "SCCACHE_S3_NO_CREDENTIALS=true" | tee -a "${GITHUB_ENV}"
+        fi
     - name: Get AWS credentials for sccache bucket
       if: ${{github.repository == 'NVIDIA/cccl'}}
       uses: aws-actions/configure-aws-credentials@v4
@@ -30,6 +38,10 @@ runs:
         role-to-assume: arn:aws:iam::279114543810:role/gha-oidc-NVIDIA
         aws-region: us-east-2
         role-duration-seconds: 43200 # 12 hours
+    - name: Configure fork GitHub token for sccache
+      if: ${{ github.repository != 'NVIDIA/cccl' && secrets.GITHUB_TOKEN != '' }}
+      shell: bash --noprofile --norc -euo pipefail {0}
+      run: echo "GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}" | tee -a "$GITHUB_ENV"
     - name: Checkout repo
       uses: actions/checkout@v4
       with:
@@ -54,6 +66,7 @@ runs:
           --isolation=process \
           --env COMMAND='& ${{inputs.command}}' \
           --env GITHUB_REPOSITORY=$GITHUB_REPOSITORY \
+          --env GITHUB_TOKEN=$GITHUB_TOKEN \
           ${{ inputs.image }} \
           powershell -c "
             [System.Environment]::SetEnvironmentVariable('AWS_ACCESS_KEY_ID','${{env.AWS_ACCESS_KEY_ID}}');


### PR DESCRIPTION
## Summary
- allow forks to provide a GITHUB_TOKEN secret for remote sccache
- fall back to local sccache with guidance when the secret is absent

## Testing
- `pre-commit run --files .github/actions/workflow-run-job-linux/action.yml .github/actions/workflow-run-job-windows/action.yml`

------
https://chatgpt.com/codex/tasks/task_e_68b9b098ab50832ba79c2617a24c133e