### PR TITLE
Add target project and args support for CI

### DIFF
--- a/.github/actions/workflow-build/build-workflow.py
+++ b/.github/actions/workflow-build/build-workflow.py
@@ -428,6 +428,11 @@ def generate_dispatch_job_name(matrix_job, job_type):
     cmake_options = (
         (" " + matrix_job["cmake_options"]) if "cmake_options" in matrix_job else ""
     )
+    extra_args = (
+        (" " + matrix_job["args"])
+        if "args" in matrix_job and matrix_job["args"]
+        else ""
+    )
 
     ctk = matrix_job["ctk"]
     host_compiler = get_host_compiler(matrix_job["cxx"])
@@ -441,8 +446,8 @@ def generate_dispatch_job_name(matrix_job, job_type):
     )
 
     extra_info = (
-        f":{cuda_compile_arch}{cmake_options}"
-        if cuda_compile_arch or cmake_options
+        f":{cuda_compile_arch}{cmake_options}{extra_args}"
+        if cuda_compile_arch or cmake_options or extra_args
         else ""
     )
 
@@ -510,6 +515,7 @@ def generate_dispatch_job_command(matrix_job, job_type):
     cmake_options = matrix_job["cmake_options"] if "cmake_options" in matrix_job else ""
 
     py_version = matrix_job["py_version"] if "py_version" in matrix_job else ""
+    extra_args = matrix_job["args"] if "args" in matrix_job else ""
 
     command = f'"{script_name}"'
     if job_args:
@@ -524,6 +530,8 @@ def generate_dispatch_job_command(matrix_job, job_type):
         command += f' -cmake-options "{cmake_options}"'
     if py_version:
         command += f' -py-version "{py_version}"'
+    if extra_args:
+        command += f" {extra_args}"
 
     return command
 
@@ -561,6 +569,9 @@ def generate_dispatch_job_origin(matrix_job, job_type):
 
         origin_job["cudacxx"] = device_compiler["id"] + device_compiler["version"]
         origin_job["cudacxx_family"] = device_compiler["name"]
+
+    if "args" in origin_job and not origin_job["args"]:
+        del origin_job["args"]
 
     origin["matrix_job"] = origin_job
 

--- a/ci/build_target.sh
+++ b/ci/build_target.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# CI wrapper for the `target` project build job.
+# Forwards all arguments to ci/util/build_and_test_targets.sh to configure
+# and build selected targets on a CPU runner.
+
+set -euo pipefail
+
+ci_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repo_dir=$(cd "${ci_dir}/.." && pwd)
+
+user_args=("$@")
+set --
+source "${ci_dir}/build_common.sh"
+set -- "${user_args[@]}"
+
+cd "${repo_dir}"
+cmd=("${ci_dir}/util/build_and_test_targets.sh" "$@")
+printf '\033[34m%s\033[0m\n' "${cmd[*]}"
+"${cmd[@]}"

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -5,9 +5,25 @@ workflows:
   #
   # Example:
   # override:
-  #   - {jobs: ['test'], project: 'thrust', std: 17, ctk: '12.X', cxx: ['gcc12', 'clang16']}
+  #   - { jobs: ['test'], project: 'thrust', std: 17, ctk: '12.X', cxx: ['gcc12', 'clang16'] }
+  #   - { jobs: ['build'], project: 'target', ctk: '13.X', cxx: 'gcc',
+  #       args: '--preset cub-cpp20 --build-targets "cub.cpp20.test.iterator"' }
+  #   - { jobs: ['test'],  project: 'target', ctk: '13.X', cxx: 'gcc',
+  #       args: '--preset cub-cpp20 --build-targets "cub.cpp20.test.iterator" --ctest-targets "cub.cpp20.test.iterator"' }
+  #   - { jobs: ['build'], project: 'target', ctk: '13.X', cxx: 'gcc',
+  #       args: '--preset libcudacxx-cpp20 --lit-precompile-tests "cuda/utility/basic_any.pass.cpp"' }
+  #   - { jobs: ['test'],  project: 'target', ctk: '13.X', cxx: 'gcc',
+  #       args: '--preset libcudacxx-cpp20 --lit-tests "cuda/utility/basic_any.pass.cpp"' }
   #
   override:
+    - { jobs: ['build'], project: 'target', ctk: '13.X', cxx: 'gcc',
+        args: '--preset cub-cpp20 --build-targets "cub.cpp20.test.iterator"' }
+    - { jobs: ['test'],  project: 'target', ctk: '13.X', cxx: 'gcc',
+        args: '--preset cub-cpp20 --build-targets "cub.cpp20.test.iterator" --ctest-targets "cub.cpp20.test.iterator"' }
+    - { jobs: ['build'], project: 'target', ctk: '13.X', cxx: 'gcc',
+        args: '--preset libcudacxx-cpp20 --lit-precompile-tests "cuda/utility/basic_any.pass.cpp"' }
+    - { jobs: ['test'],  project: 'target', ctk: '13.X', cxx: 'gcc',
+        args: '--preset libcudacxx-cpp20 --lit-tests "cuda/utility/basic_any.pass.cpp"' }
 
   pull_request:
     # Old CTK: Oldest/newest supported host compilers:
@@ -452,6 +468,18 @@ projects:
     name: 'CCCL C Parallel'
     stds: [20]
 
+  # Run specific build_and_test_targets.sh invocations across the CI matrix.
+  # Use the override workflow and supply arguments via the `args` tag.
+  # Example:
+  #   override:
+  #     - { jobs: ['test'], project: 'target', ctk: '13.X', cxx: 'gcc',
+  #         args: '--preset cub-cpp20 --build-targets "cub.cpp20.test.iterator" --ctest-targets "cub.cpp20.test.iterator"' }
+  target:
+    name: 'Target'
+    stds: [17, 20]
+    job_map:
+      test: ['test_nobuild']
+
 # testing -> Runner with GPU is in a nv-gh-runners testing pool
 gpus:
   v100:     { sm: 70 } # 32 GB,  40 runners
@@ -508,3 +536,7 @@ tags:
   # Additional CMake options to pass to the build.
   # If set, passed to script with `-cmake_options "<cmake_options>"`.
   cmake_options: { required: false }
+  # Additional arguments appended to the generated command.
+  # Typically used with the `target` project to forward options to
+  # ci/util/build_and_test_targets.sh, but works with all CI jobs.
+  args: { required: false, default: "" }

--- a/ci/test_target.sh
+++ b/ci/test_target.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# CI wrapper for the `target` project test job.
+# Invokes ci/util/build_and_test_targets.sh with the provided arguments to
+# build and test selected targets on a GPU runner.
+
+set -euo pipefail
+
+ci_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repo_dir=$(cd "${ci_dir}/.." && pwd)
+
+user_args=("$@")
+set --
+source "${ci_dir}/build_common.sh"
+set -- "${user_args[@]}"
+
+cd "${repo_dir}"
+cmd=("${ci_dir}/util/build_and_test_targets.sh" "$@")
+printf '\033[34m%s\033[0m\n' "${cmd[*]}"
+"${cmd[@]}"


### PR DESCRIPTION
## Summary
- add universal `args` tag to CI matrix and workflow generator
- expose `target` project with wrappers around build_and_test_targets.sh
- allow override workflow to run ad-hoc target builds/tests across configs
- colorize target wrapper scripts to echo the invoked build_and_test_targets command in blue
- mark non-GPU target overrides as build jobs

## Testing
- `pre-commit run --files ci/matrix.yaml`
- `python .github/actions/workflow-build/build-workflow.py ci/matrix.yaml --workflows pull_request --allow-override`
- `timeout 10 ci/build_target.sh --preset cub-cpp20 --build-targets "cub.cpp20.test.iterator"`
- `timeout 10 ci/test_target.sh --preset cub-cpp20 --build-targets "cub.cpp20.test.iterator"`


------
https://chatgpt.com/codex/tasks/task_e_68ba3bccd5c4832bb8fdb1c866aed8a6