### PR TITLE
Sort workflow job times by duration

### DIFF
--- a/.github/actions/workflow-results/parse-job-times.py
+++ b/.github/actions/workflow-results/parse-job-times.py
@@ -128,7 +128,12 @@ def main():
         f.write("<details><summary>⏱️ Job Times</summary>\n\n")
         f.write("| Job Duration | Command Duration | Overhead (%) | Name |\n")
         f.write("|--------------|------------------|--------------|------|\n")
-        for id, stats in result.items():
+
+        sorted_stats = sorted(
+            result.values(), key=lambda s: s["job_seconds"], reverse=True
+        )
+
+        for stats in sorted_stats:
             job_seconds = stats["job_seconds"]
             command_seconds = stats["command_seconds"]
             overhead = (


### PR DESCRIPTION
## Summary
- sort workflow job times in step summary from longest to shortest

## Testing
- `pre-commit run --files .github/actions/workflow-results/parse-job-times.py`


------
https://chatgpt.com/codex/tasks/task_e_68bdc33a3618832b8d6f17eccca0eabb