### PR TITLE
feat(ci): enable sccache PAT usage for forks

### DIFF
--- a/.github/actions/workflow-run-job-linux/action.yml
+++ b/.github/actions/workflow-run-job-linux/action.yml
@@ -20,6 +20,12 @@ inputs:
   host:
     description: "The host compiler to use when selecting a devcontainer."
     required: true
+  fork_sccache_auth_pat:
+    description: >-
+      Optional GitHub personal access token for enabling sccache from personal forks.
+      Requires the `repo`, `read:org`, and `gist` scopes.
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -50,24 +56,12 @@ runs:
       run: |
         echo "::add-matcher::${{github.workspace}}/.github/problem-matchers/problem-matcher.json"
     - name: Get AWS credentials for sccache bucket
-      if: ${{github.repository == 'NVIDIA/cccl'}}
       uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: arn:aws:iam::279114543810:role/gha-oidc-NVIDIA
         aws-region: us-east-2
         role-duration-seconds: 43200 # 12 hours
-    - name: Configure fork GitHub token for sccache
-      if: ${{ github.repository != 'NVIDIA/cccl' }}
-      shell: bash --noprofile --norc -euo pipefail {0}
-      env:
-        FORK_GH_TOKEN: ${{ secrets.SCCACHE_AUTH_TOKEN }}
-      run: |
-        if [[ -n "${FORK_GH_TOKEN}" ]]; then
-          echo "GITHUB_TOKEN=${FORK_GH_TOKEN}" | tee -a "$GITHUB_ENV"
-        else
-          echo "::warning::sccache remote cache is disabled for forks by default."
-          echo "::warning::Create a GitHub PAT with gist, repo, read:org scopes and add it as the GITHUB_TOKEN secret to enable remote sccache."
-        fi
+        github-token: ${{ inputs.fork_sccache_auth_pat || github.token }}
     - name: Print CI override matrix job def
       env:
         GH_TOKEN: ${{ github.token }}
@@ -95,6 +89,7 @@ runs:
       shell: bash --noprofile --norc -euo pipefail {0}
       env:
         GH_TOKEN: ${{ github.token }}
+        FORK_GH_TOKEN: ${{ inputs.fork_sccache_auth_pat }}
         CI: true
         # Dereferencing the command from an env var instead of a GHA input avoids issues with escaping
         # semicolons and other special characters (e.g. `-arch "60;70;80"`).
@@ -170,6 +165,12 @@ runs:
         source ci/util/artifacts/common.sh
         source ci/util/workflow/common.sh
 
+        # GH_TOKEN authenticates the gh CLI; GITHUB_TOKEN (optional) enables sccache.
+        sccache_token_env=()
+        if [[ -n "${FORK_GH_TOKEN}" ]]; then
+          sccache_token_env+=(--env "GITHUB_TOKEN=${FORK_GH_TOKEN}")
+        fi
+
         # Launch this container using the host's docker daemon
         ( # Subshell to contain the set -x log
           set -x
@@ -191,8 +192,8 @@ runs:
             --env "GITHUB_WORKSPACE=$GITHUB_WORKSPACE" \
             --env "GITHUB_REPOSITORY=$GITHUB_REPOSITORY" \
             --env "GITHUB_STEP_SUMMARY=$GITHUB_STEP_SUMMARY" \
-            --env "GH_TOKEN=${{ github.token }}" \
-            --env "GITHUB_TOKEN=${GITHUB_TOKEN:-}" \
+            --env "GH_TOKEN=${GH_TOKEN}" \
+            "${sccache_token_env[@]}" \
             --env "HOST_WORKSPACE=${{github.workspace}}" \
             --env "NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES:-}" \
             --env "JOB_ID=$JOB_ID" \

--- a/.github/actions/workflow-run-job-windows/action.yml
+++ b/.github/actions/workflow-run-job-windows/action.yml
@@ -11,6 +11,12 @@ inputs:
   image:
     description: "The Docker image to use."
     required: true
+  fork_sccache_auth_pat:
+    description: >-
+      Optional GitHub personal access token for enabling sccache from personal forks.
+      Requires the `repo`, `read:org`, and `gist` scopes.
+    required: false
+    default: ""
 
 runs:
   using: "composite"
@@ -18,7 +24,7 @@ runs:
     - name: Configure sccache
       shell: bash --noprofile --norc -euo pipefail {0}
       env:
-        FORK_GH_TOKEN: ${{ secrets.SCCACHE_AUTH_TOKEN }}
+        FORK_GH_TOKEN: ${{ inputs.fork_sccache_auth_pat }}
       run: |
         if [[ "${{ github.repository }}" == "NVIDIA/cccl" || -n "${FORK_GH_TOKEN}" ]]; then
           echo "SCCACHE_BUCKET=rapids-sccache-devs" | tee -a "${GITHUB_ENV}"
@@ -28,20 +34,16 @@ runs:
           echo "SCCACHE_S3_NO_CREDENTIALS=false" | tee -a "${GITHUB_ENV}"
         else
           echo "::warning::sccache remote cache is disabled for forks by default."
-          echo "::warning::Create a GitHub PAT with gist, repo, read:org scopes and add it as the GITHUB_TOKEN secret to enable remote sccache."
+          echo "::warning::Create a GitHub PAT with gist, repo, read:org scopes and pass it via fork_sccache_auth_pat to enable remote sccache."
           echo "SCCACHE_S3_NO_CREDENTIALS=true" | tee -a "${GITHUB_ENV}"
         fi
     - name: Get AWS credentials for sccache bucket
-      if: ${{github.repository == 'NVIDIA/cccl'}}
       uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: arn:aws:iam::279114543810:role/gha-oidc-NVIDIA
         aws-region: us-east-2
         role-duration-seconds: 43200 # 12 hours
-    - name: Configure fork GitHub token for sccache
-      if: ${{ github.repository != 'NVIDIA/cccl' && secrets.SCCACHE_AUTH_TOKEN != '' }}
-      shell: bash --noprofile --norc -euo pipefail {0}
-      run: echo "GITHUB_TOKEN=${{ secrets.SCCACHE_AUTH_TOKEN }}" | tee -a "$GITHUB_ENV"
+        github-token: ${{ inputs.fork_sccache_auth_pat || github.token }}
     - name: Checkout repo
       uses: actions/checkout@v4
       with:
@@ -59,14 +61,20 @@ runs:
         cat $env:GITHUB_OUTPUT
     - name: Run command # Do not change this step's name, it is checked in parse-job-times.py
       shell: bash --noprofile --norc -euo pipefail {0}
+      env:
+        FORK_GH_TOKEN: ${{ inputs.fork_sccache_auth_pat }}
       run: |
+        sccache_token_arg=()
+        if [[ -n "${FORK_GH_TOKEN}" ]]; then
+          sccache_token_arg+=(--env GITHUB_TOKEN="${FORK_GH_TOKEN}")
+        fi
         docker run \
           --mount type=bind,source="${{steps.paths.outputs.HOST_REPO}}",target="${{steps.paths.outputs.MOUNT_REPO}}" \
           --workdir "${{steps.paths.outputs.MOUNT_REPO}}" \
           --isolation=process \
           --env COMMAND='& ${{inputs.command}}' \
-          --env GITHUB_REPOSITORY=$GITHUB_REPOSITORY \
-          --env GITHUB_TOKEN=$GITHUB_TOKEN \
+          --env GITHUB_REPOSITORY="$GITHUB_REPOSITORY" \
+          "${sccache_token_arg[@]}" \
           ${{ inputs.image }} \
           powershell -c "
             [System.Environment]::SetEnvironmentVariable('AWS_ACCESS_KEY_ID','${{env.AWS_ACCESS_KEY_ID}}');

--- a/.github/workflows/build-and-test-python-wheels.yml
+++ b/.github/workflows/build-and-test-python-wheels.yml
@@ -42,6 +42,7 @@ jobs:
     uses: ./.github/workflows/workflow-dispatch-two-stage-group-linux.yml
     with:
       pc-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_two_stage']['jobs'][matrix.name]) }}
+    secrets: inherit
 
   dispatch-groups-windows-two-stage:
     name: ${{ matrix.name }}
@@ -57,6 +58,7 @@ jobs:
     uses: ./.github/workflows/workflow-dispatch-two-stage-group-windows.yml
     with:
       pc-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_two_stage']['jobs'][matrix.name]) }}
+    secrets: inherit
 
   dispatch-groups-linux-standalone:
     name: ${{ matrix.name }}
@@ -72,6 +74,7 @@ jobs:
     uses: ./.github/workflows/workflow-dispatch-standalone-group-linux.yml
     with:
       job-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_standalone']['jobs'][matrix.name]) }}
+    secrets: inherit
 
   dispatch-groups-windows-standalone:
     name: ${{ matrix.name }}
@@ -87,6 +90,7 @@ jobs:
     uses: ./.github/workflows/workflow-dispatch-standalone-group-windows.yml
     with:
       job-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_standalone']['jobs'][matrix.name]) }}
+    secrets: inherit
 
   verify-workflow:
     name: Verify and summarize workflow results

--- a/.github/workflows/ci-workflow-nightly.yml
+++ b/.github/workflows/ci-workflow-nightly.yml
@@ -65,6 +65,7 @@ jobs:
     uses: ./.github/workflows/workflow-dispatch-two-stage-group-linux.yml
     with:
       pc-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_two_stage']['jobs'][matrix.name]) }}
+    secrets: inherit
 
   dispatch-groups-windows-two-stage:
     name: ${{ matrix.name }}
@@ -80,6 +81,7 @@ jobs:
     uses: ./.github/workflows/workflow-dispatch-two-stage-group-windows.yml
     with:
       pc-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_two_stage']['jobs'][matrix.name]) }}
+    secrets: inherit
 
   dispatch-groups-linux-standalone:
     name: ${{ matrix.name }}
@@ -95,6 +97,7 @@ jobs:
     uses: ./.github/workflows/workflow-dispatch-standalone-group-linux.yml
     with:
       job-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_standalone']['jobs'][matrix.name]) }}
+    secrets: inherit
 
   dispatch-groups-windows-standalone:
     name: ${{ matrix.name }}
@@ -110,6 +113,7 @@ jobs:
     uses: ./.github/workflows/workflow-dispatch-standalone-group-windows.yml
     with:
       job-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_standalone']['jobs'][matrix.name]) }}
+    secrets: inherit
 
   verify-workflow:
     name: Verify and summarize workflow results

--- a/.github/workflows/ci-workflow-pull-request.yml
+++ b/.github/workflows/ci-workflow-pull-request.yml
@@ -114,6 +114,7 @@ jobs:
     uses: ./.github/workflows/workflow-dispatch-two-stage-group-linux.yml
     with:
       pc-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_two_stage']['jobs'][matrix.name]) }}
+    secrets: inherit
 
   dispatch-groups-windows-two-stage:
     name: ${{ matrix.name }}
@@ -134,6 +135,7 @@ jobs:
     uses: ./.github/workflows/workflow-dispatch-two-stage-group-windows.yml
     with:
       pc-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_two_stage']['jobs'][matrix.name]) }}
+    secrets: inherit
 
   dispatch-groups-linux-standalone:
     name: ${{ matrix.name }}
@@ -154,6 +156,7 @@ jobs:
     uses: ./.github/workflows/workflow-dispatch-standalone-group-linux.yml
     with:
       job-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_standalone']['jobs'][matrix.name]) }}
+    secrets: inherit
 
   dispatch-groups-windows-standalone:
     name: ${{ matrix.name }}
@@ -174,6 +177,7 @@ jobs:
     uses: ./.github/workflows/workflow-dispatch-standalone-group-windows.yml
     with:
       job-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_standalone']['jobs'][matrix.name]) }}
+    secrets: inherit
 
   verify-workflow:
     name: Verify and summarize workflow results

--- a/.github/workflows/ci-workflow-weekly.yml
+++ b/.github/workflows/ci-workflow-weekly.yml
@@ -64,6 +64,7 @@ jobs:
     uses: ./.github/workflows/workflow-dispatch-two-stage-group-linux.yml
     with:
       pc-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_two_stage']['jobs'][matrix.name]) }}
+    secrets: inherit
 
   dispatch-groups-windows-two-stage:
     name: ${{ matrix.name }}
@@ -79,6 +80,7 @@ jobs:
     uses: ./.github/workflows/workflow-dispatch-two-stage-group-windows.yml
     with:
       pc-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_two_stage']['jobs'][matrix.name]) }}
+    secrets: inherit
 
   dispatch-groups-linux-standalone:
     name: ${{ matrix.name }}
@@ -94,6 +96,7 @@ jobs:
     uses: ./.github/workflows/workflow-dispatch-standalone-group-linux.yml
     with:
       job-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['linux_standalone']['jobs'][matrix.name]) }}
+    secrets: inherit
 
   dispatch-groups-windows-standalone:
     name: ${{ matrix.name }}
@@ -109,6 +112,7 @@ jobs:
     uses: ./.github/workflows/workflow-dispatch-standalone-group-windows.yml
     with:
       job-array: ${{ toJSON(fromJSON(needs.build-workflow.outputs.workflow)['windows_standalone']['jobs'][matrix.name]) }}
+    secrets: inherit
 
   verify-workflow:
     name: Verify and summarize workflow results

--- a/.github/workflows/workflow-dispatch-standalone-group-linux.yml
+++ b/.github/workflows/workflow-dispatch-standalone-group-linux.yml
@@ -37,3 +37,4 @@ jobs:
           runner:  ${{ matrix.runner }}
           cuda:    ${{ matrix.cuda }}
           host:    ${{ matrix.host }}
+          fork_sccache_auth_pat: ${{ github.repository != 'NVIDIA/cccl' && secrets.SCCACHE_AUTH_TOKEN || '' }}

--- a/.github/workflows/workflow-dispatch-standalone-group-windows.yml
+++ b/.github/workflows/workflow-dispatch-standalone-group-windows.yml
@@ -34,3 +34,4 @@ jobs:
           id:      ${{ matrix.id }}
           command: ${{ matrix.command }}
           image:   ${{ matrix.image }}
+          fork_sccache_auth_pat: ${{ github.repository != 'NVIDIA/cccl' && secrets.SCCACHE_AUTH_TOKEN || '' }}

--- a/.github/workflows/workflow-dispatch-two-stage-group-linux.yml
+++ b/.github/workflows/workflow-dispatch-two-stage-group-linux.yml
@@ -26,3 +26,4 @@ jobs:
     with:
       producers: ${{ toJSON(matrix.producers) }}
       consumers: ${{ toJSON(matrix.consumers) }}
+    secrets: inherit

--- a/.github/workflows/workflow-dispatch-two-stage-group-windows.yml
+++ b/.github/workflows/workflow-dispatch-two-stage-group-windows.yml
@@ -26,3 +26,4 @@ jobs:
     with:
       producers: ${{ toJSON(matrix.producers) }}
       consumers: ${{ toJSON(matrix.consumers) }}
+    secrets: inherit

--- a/.github/workflows/workflow-dispatch-two-stage-linux.yml
+++ b/.github/workflows/workflow-dispatch-two-stage-linux.yml
@@ -39,6 +39,7 @@ jobs:
           runner:  ${{ fromJSON(inputs.producers)[0].runner }}
           cuda:    ${{ fromJSON(inputs.producers)[0].cuda }}
           host:    ${{ fromJSON(inputs.producers)[0].host }}
+          fork_sccache_auth_pat: ${{ github.repository != 'NVIDIA/cccl' && secrets.SCCACHE_AUTH_TOKEN || '' }}
 
   consumers:
     name: "${{ matrix.name }}"
@@ -65,3 +66,4 @@ jobs:
           runner:  ${{ matrix.runner }}
           cuda:    ${{ matrix.cuda }}
           host:    ${{ matrix.host }}
+          fork_sccache_auth_pat: ${{ github.repository != 'NVIDIA/cccl' && secrets.SCCACHE_AUTH_TOKEN || '' }}

--- a/.github/workflows/workflow-dispatch-two-stage-windows.yml
+++ b/.github/workflows/workflow-dispatch-two-stage-windows.yml
@@ -36,6 +36,7 @@ jobs:
           id:      ${{ fromJSON(inputs.producers)[0].id }}
           command: ${{ fromJSON(inputs.producers)[0].command }}
           image:   ${{ fromJSON(inputs.producers)[0].image }}
+          fork_sccache_auth_pat: ${{ github.repository != 'NVIDIA/cccl' && secrets.SCCACHE_AUTH_TOKEN || '' }}
 
   consumers:
     name: ${{ matrix.name }}
@@ -59,3 +60,4 @@ jobs:
           id:      ${{ matrix.id }}
           command: ${{ matrix.command }}
           image:   ${{ matrix.image }}
+          fork_sccache_auth_pat: ${{ github.repository != 'NVIDIA/cccl' && secrets.SCCACHE_AUTH_TOKEN || '' }}


### PR DESCRIPTION
## Summary
- add optional `fork_sccache_auth_pat` input to run-job actions
- re-enable AWS credential step for forks and drop secrets-based token path
- wire callers to pass `SCCACHE_AUTH_TOKEN` secret when available
- inject fork tokens directly into run steps without logging

## Testing
- `pre-commit run --files .github/actions/workflow-run-job-linux/action.yml .github/actions/workflow-run-job-windows/action.yml`


------
https://chatgpt.com/codex/tasks/task_e_68ba2095f4fc832b8abca1ad9f1884dc